### PR TITLE
Alterar ícones para formato quadrado

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,9 @@
       </div>
       <div id="frequencyC" style="display: none;" class="info">
         <svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="17" cy="17" r="17" fill="url(#paint0_linear_57_985)" fill-opacity="0.85"/>
-          <circle cx="17" cy="17" r="16" stroke="#FFFFFF" stroke-opacity="1.0" stroke-width="2"/>
-          <circle cx="17" cy="17" r="16" stroke="url(#paint1_linear_57_985)" stroke-opacity="0.15" stroke-width="2"/>
+          <rect x="1" y="1" width="32" height="32" rx="4" fill="url(#paint0_linear_57_985)" fill-opacity="0.85"/>
+          <rect x="2" y="2" width="30" height="30" rx="3" stroke="#FFFFFF" stroke-opacity="1.0" stroke-width="2" fill="none"/>
+          <rect x="2" y="2" width="30" height="30" rx="3" stroke="url(#paint1_linear_57_985)" stroke-opacity="0.15" stroke-width="2" fill="none"/>
           <path d="M13.2745 12.9837C13.2745 12.0101 13.2763 11.0765 13.2745 10.1422C13.2728 9.6551 13.4871 9.26763 14.0758 9.0753C14.8972 8.80786 15.7615 9.28307 15.7798 10.0222C15.7999 10.8758 15.7851 11.7293 15.7859 12.5836C15.7859 12.7092 15.7859 12.8356 15.7859 12.9788H18.1548C18.3796 11.9595 18.3927 11.9518 19.8536 11.9806C20.5035 11.9932 20.6137 12.1147 20.7406 12.9823C20.8727 12.9893 21.0126 12.9977 21.1517 13.004C21.7325 13.0307 21.9958 13.2406 21.9967 13.7151C22.0011 16.9075 22.0011 20.1006 21.9967 23.293C21.9967 23.7794 21.7133 23.9984 21.1071 23.9984C18.3796 24.0005 15.6512 24.0005 12.9237 23.9984C12.2939 23.9984 12.0035 23.7731 12.0026 23.2775C11.9991 20.0964 11.9991 16.9159 12.0026 13.7347C12.0026 13.2448 12.2598 13.0384 12.8739 13.004C12.9885 12.9977 13.1039 12.9921 13.2754 12.9823L13.2745 12.9837ZM13.243 15.0249V18.013H20.6592V15.0249H13.243ZM18.7776 22.0723H15.1316V22.9989H18.7776V22.0723Z" fill="white"/>
           <defs>
           <linearGradient id="paint0_linear_57_985" x1="17" y1="0" x2="17" y2="34" gradientUnits="userSpaceOnUse">
@@ -207,13 +207,10 @@
     <div class="player-status">
       <div class="status">
         <svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M21 1.5C26.1246 1.5 31.0432 3.5173 34.6921 7.11558C38.3409 10.7139 40.4266 15.6039 40.4981 20.728C40.5696 25.8521 38.6211 30.7984 35.0741 34.4971C31.527 38.1957 26.6666 40.3495 21.544 40.4924C16.4214 40.6354 11.4484 38.7561 7.70058 35.261C3.95279 31.7659 1.73148 26.936 1.51707 21.8158C1.30267 16.6957 3.11242 11.697 6.55489 7.90081C9.99736 4.10463 14.7958 1.81615 19.9125 1.53035"
-            stroke="#FFFFFF" stroke-opacity="0.07" stroke-width="3" stroke-linecap="round" />
-          <path pathLength="100.01" stroke-dasharray="100.01" stroke-dashoffset="40"
+          <rect x="3" y="3" width="36" height="36" rx="4" stroke="#FFFFFF" stroke-opacity="0.07" stroke-width="3" fill="none"/>
+          <rect x="3" y="3" width="36" height="36" rx="4" pathLength="100.01" stroke-dasharray="100.01" stroke-dashoffset="40"
           id="thirst-status"
-          d="M21 1.5C26.1246 1.5 31.0432 3.5173 34.6921 7.11558C38.3409 10.7139 40.4266 15.6039 40.4981 20.728C40.5696 25.8521 38.6211 30.7984 35.0741 34.4971C31.527 38.1957 26.6666 40.3495 21.544 40.4924C16.4214 40.6354 11.4484 38.7561 7.70058 35.261C3.95279 31.7659 1.73148 26.936 1.51707 21.8158C1.30267 16.6957 3.11242 11.697 6.55489 7.90081C9.99736 4.10463 14.7958 1.81615 19.9125 1.53035"
-            stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" />
+          stroke="#FFFFFF" stroke-width="3" fill="none"/>
           <defs>
             <linearGradient id="paint0_linear_2033_47" x1="0" y1="0" x2="42" y2="42" gradientUnits="userSpaceOnUse">
               <stop stop-color="white" />
@@ -233,14 +230,11 @@
       </div>
       <div class="status">
         <svg  width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M21 1.5C26.1246 1.5 31.0432 3.5173 34.6921 7.11558C38.3409 10.7139 40.4266 15.6039 40.4981 20.728C40.5696 25.8521 38.6211 30.7984 35.0741 34.4971C31.527 38.1957 26.6666 40.3495 21.544 40.4924C16.4214 40.6354 11.4484 38.7561 7.70058 35.261C3.95279 31.7659 1.73148 26.936 1.51707 21.8158C1.30267 16.6957 3.11242 11.697 6.55489 7.90081C9.99736 4.10463 14.7958 1.81615 19.9125 1.53035"
-            stroke="#FFFFFF" stroke-opacity="0.07" stroke-width="3" stroke-linecap="round" />
-          <path
+          <rect x="3" y="3" width="36" height="36" rx="4" stroke="#FFFFFF" stroke-opacity="0.07" stroke-width="3" fill="none"/>
+          <rect x="3" y="3" width="36" height="36" rx="4"
           id="hunger-status"
             pathLength="100.01" stroke-dasharray="100.01" stroke-dashoffset="40"
-            d="M21 1.5C26.1246 1.5 31.0432 3.5173 34.6921 7.11558C38.3409 10.7139 40.4266 15.6039 40.4981 20.728C40.5696 25.8521 38.6211 30.7984 35.0741 34.4971C31.527 38.1957 26.6666 40.3495 21.544 40.4924C16.4214 40.6354 11.4484 38.7561 7.70058 35.261C3.95279 31.7659 1.73148 26.936 1.51707 21.8158C1.30267 16.6957 3.11242 11.697 6.55489 7.90081C9.99736 4.10463 14.7958 1.81615 19.9125 1.53035"
-            stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" />
+            stroke="#FFFFFF" stroke-width="3" fill="none"/>
           <defs>
             <linearGradient id="paint0_linear_2033_47" x1="0" y1="0" x2="42" y2="42" gradientUnits="userSpaceOnUse">
               <stop stop-color="white" />
@@ -260,13 +254,10 @@
       </div>
       <div class="status">
         <svg  width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M21 1.5C26.1246 1.5 31.0432 3.5173 34.6921 7.11558C38.3409 10.7139 40.4266 15.6039 40.4981 20.728C40.5696 25.8521 38.6211 30.7984 35.0741 34.4971C31.527 38.1957 26.6666 40.3495 21.544 40.4924C16.4214 40.6354 11.4484 38.7561 7.70058 35.261C3.95279 31.7659 1.73148 26.936 1.51707 21.8158C1.30267 16.6957 3.11242 11.697 6.55489 7.90081C9.99736 4.10463 14.7958 1.81615 19.9125 1.53035"
-            stroke="#FFFFFF" stroke-opacity="0.07" stroke-width="3" stroke-linecap="round" />
-          <path
+          <rect x="3" y="3" width="36" height="36" rx="4" stroke="#FFFFFF" stroke-opacity="0.07" stroke-width="3" fill="none"/>
+          <rect x="3" y="3" width="36" height="36" rx="4"
             id="shield-status"            pathLength="100.01" stroke-dasharray="100.01" stroke-dashoffset="40"
-            d="M21 1.5C26.1246 1.5 31.0432 3.5173 34.6921 7.11558C38.3409 10.7139 40.4266 15.6039 40.4981 20.728C40.5696 25.8521 38.6211 30.7984 35.0741 34.4971C31.527 38.1957 26.6666 40.3495 21.544 40.4924C16.4214 40.6354 11.4484 38.7561 7.70058 35.261C3.95279 31.7659 1.73148 26.936 1.51707 21.8158C1.30267 16.6957 3.11242 11.697 6.55489 7.90081C9.99736 4.10463 14.7958 1.81615 19.9125 1.53035"
-            stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" />
+            stroke="#FFFFFF" stroke-width="3" fill="none"/>
           <defs>
             <linearGradient id="paint0_linear_2033_47" x1="0" y1="0" x2="42" y2="42" gradientUnits="userSpaceOnUse">
               <stop stop-color="white" />
@@ -286,13 +277,10 @@
       </div>
       <div class="status">
         <svg  width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M21 1.5C26.1246 1.5 31.0432 3.5173 34.6921 7.11558C38.3409 10.7139 40.4266 15.6039 40.4981 20.728C40.5696 25.8521 38.6211 30.7984 35.0741 34.4971C31.527 38.1957 26.6666 40.3495 21.544 40.4924C16.4214 40.6354 11.4484 38.7561 7.70058 35.261C3.95279 31.7659 1.73148 26.936 1.51707 21.8158C1.30267 16.6957 3.11242 11.697 6.55489 7.90081C9.99736 4.10463 14.7958 1.81615 19.9125 1.53035"
-            stroke="#FFFFFF" stroke-opacity="0.07" stroke-width="3" stroke-linecap="round" />
-          <path id="health-status" pathLength="100.01" stroke-dasharray="100.01" stroke-dashoffset="40"
+          <rect x="3" y="3" width="36" height="36" rx="4" stroke="#FFFFFF" stroke-opacity="0.07" stroke-width="3" fill="none"/>
+          <rect x="3" y="3" width="36" height="36" rx="4" id="health-status" pathLength="100.01" stroke-dasharray="100.01" stroke-dashoffset="40"
             id="health"  
-          d="M21 1.5C26.1246 1.5 31.0432 3.5173 34.6921 7.11558C38.3409 10.7139 40.4266 15.6039 40.4981 20.728C40.5696 25.8521 38.6211 30.7984 35.0741 34.4971C31.527 38.1957 26.6666 40.3495 21.544 40.4924C16.4214 40.6354 11.4484 38.7561 7.70058 35.261C3.95279 31.7659 1.73148 26.936 1.51707 21.8158C1.30267 16.6957 3.11242 11.697 6.55489 7.90081C9.99736 4.10463 14.7958 1.81615 19.9125 1.53035"
-            stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" />
+          stroke="#FFFFFF" stroke-width="3" fill="none"/>
           <defs>
             <linearGradient id="paint0_linear_2033_47" x1="0" y1="0" x2="42" y2="42" gradientUnits="userSpaceOnUse">
               <stop stop-color="white" />
@@ -312,13 +300,10 @@
       </div>
       <div id="progressC" class="status" style="display: none;">
         <svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M21 1.5C26.1246 1.5 31.0432 3.5173 34.6921 7.11558C38.3409 10.7139 40.4266 15.6039 40.4981 20.728C40.5696 25.8521 38.6211 30.7984 35.0741 34.4971C31.527 38.1957 26.6666 40.3495 21.544 40.4924C16.4214 40.6354 11.4484 38.7561 7.70058 35.261C3.95279 31.7659 1.73148 26.936 1.51707 21.8158C1.30267 16.6957 3.11242 11.697 6.55489 7.90081C9.99736 4.10463 14.7958 1.81615 19.9125 1.53035"
-            stroke="#FFFFFF" stroke-opacity="0.07" stroke-width="3" stroke-linecap="round" />
-          <path pathLength="100.01" stroke-dasharray="100.01" stroke-dashoffset="40"
+          <rect x="3" y="3" width="36" height="36" rx="4" stroke="#FFFFFF" stroke-opacity="0.07" stroke-width="3" fill="none"/>
+          <rect x="3" y="3" width="36" height="36" rx="4" pathLength="100.01" stroke-dasharray="100.01" stroke-dashoffset="40"
           id="progress"  
-          d="M21 1.5C26.1246 1.5 31.0432 3.5173 34.6921 7.11558C38.3409 10.7139 40.4266 15.6039 40.4981 20.728C40.5696 25.8521 38.6211 30.7984 35.0741 34.4971C31.527 38.1957 26.6666 40.3495 21.544 40.4924C16.4214 40.6354 11.4484 38.7561 7.70058 35.261C3.95279 31.7659 1.73148 26.936 1.51707 21.8158C1.30267 16.6957 3.11242 11.697 6.55489 7.90081C9.99736 4.10463 14.7958 1.81615 19.9125 1.53035"
-            stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" />
+          stroke="#FFFFFF" stroke-width="3" fill="none"/>
           <defs>
             <linearGradient id="paint0_linear_2033_47" x1="0" y1="0" x2="42" y2="42" gradientUnits="userSpaceOnUse">
               <stop stop-color="white" />

--- a/style.css
+++ b/style.css
@@ -28,7 +28,7 @@ body {
   justify-content: center;
   gap: 0.5rem;
   padding: 0.62rem;
-  border-radius: 0.325rem;
+  border-radius: 4px;
 
   color: #fff;
   font-family: Sora;
@@ -42,7 +42,7 @@ body {
   width: 0.625rem;
   height: 0.625rem;
   flex-shrink: 0;
-  border-radius: 0.375rem;
+  border-radius: 2px;
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(255, 255, 255, 0.25);
 }
@@ -108,7 +108,7 @@ body {
   width: 1.4375rem;
   height: 2.375rem;
   flex-shrink: 0;
-  border-radius: 1.4375rem;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(19, 19, 19, 0.395);
   display: grid;
@@ -127,7 +127,7 @@ body {
   flex-shrink: 0;
   display: flex;
   align-items: flex-end;
-  border-radius: 1.4375rem;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.1);
 }
 
@@ -136,7 +136,7 @@ body {
   height: 100%;
   flex-shrink: 0;
   background-color: white;
-  border-radius: 1.4375rem;
+  border-radius: 8px;
 }
 
 .player-status {
@@ -154,7 +154,7 @@ body {
   width: 42px;
   height: 42px;
   flex-shrink: 0;
-  border-radius: 50%;
+  border-radius: 8px;
   background: linear-gradient(
     180deg,
     rgba(23, 23, 23, 0.85) 0%,
@@ -182,7 +182,7 @@ body {
   stroke-dasharray: 216;
   stroke-dashoffset: 98;
   transform: rotate(26deg);
-  border-radius: 1rem;
+  border-radius: 4px;
   transition: all 0.4s linear;
 }
 
@@ -194,7 +194,7 @@ body {
   stroke-dasharray: 216;
   stroke-dashoffset: -100;
   transform: rotate(26deg);
-  border-radius: 1rem;
+  border-radius: 4px;
 }
 
 .vehicleHud {
@@ -337,7 +337,7 @@ body {
   stroke-dasharray: 302;
   stroke-dashoffset: 190;
   /* transform: rotate(26deg); */
-  border-radius: 1rem;
+  border-radius: 4px;
 }
 
 .vehicleNitro {
@@ -359,7 +359,7 @@ body {
   stroke-dasharray: 450;
   stroke-dashoffset: 300;
   transform: scaleX(-1);
-  border-radius: 1rem;
+  border-radius: 4px;
 }
 
 #nitroIcon {
@@ -372,7 +372,7 @@ body {
   width: 17.375rem;
   height: 4.625rem;
   flex-shrink: 0;
-  border-radius: 0.5rem;
+  border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(19, 19, 19, 0.7953);
   position: absolute;
@@ -392,7 +392,7 @@ body {
   width: 15.5rem;
   height: 1rem;
   flex-shrink: 0;
-  border-radius: 0.5rem;
+  border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(19, 19, 19, 0.395);
   margin-top: 0.55rem;
@@ -402,7 +402,7 @@ body {
   width: 50%;
   height: 1rem;
   flex-shrink: 0;
-  border-radius: 0.5rem;
+  border-radius: 4px;
   background: #fff;
 }
 
@@ -421,7 +421,7 @@ body {
   padding: 0.5rem;
   align-items: center;
   gap: 0.3125rem;
-  border-radius: 0.325rem;
+  border-radius: 4px;
 }
 
 .weaponHud .container span {


### PR DESCRIPTION
Altera elementos da interface de redondo para quadrado (fome, sede, vida, colete, mic, relógio, rádio, etc.) conforme solicitado.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4108ed5-1077-40cd-9bf1-a3555dd4c538">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4108ed5-1077-40cd-9bf1-a3555dd4c538">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>